### PR TITLE
feature: 리더 크루 논리 삭제 API 구현

### DIFF
--- a/src/main/java/com/retrip/crew/application/in/CrewService.java
+++ b/src/main/java/com/retrip/crew/application/in/CrewService.java
@@ -3,6 +3,9 @@ package com.retrip.crew.application.in;
 import com.retrip.crew.application.in.request.IntroductionCreateRequest;
 import com.retrip.crew.application.in.request.IntroductionDeleteRequest;
 import com.retrip.crew.application.in.request.IntroductionUpdateRequest;
+import com.retrip.crew.application.in.request.crew.CrewCreateRequest;
+import com.retrip.crew.application.in.request.crew.CrewOrder;
+import com.retrip.crew.application.in.request.crew.CrewUpdateRequest;
 import com.retrip.crew.application.in.request.crew.*;
 import com.retrip.crew.application.in.response.IntroductionCreateResponse;
 import com.retrip.crew.application.in.response.IntroductionDetailResponse;
@@ -144,5 +147,11 @@ public class CrewService implements ManageCrewUseCase, GetCrewUseCase, ManageInt
         CrewMembers crewMembers = crew.getCrewMembers();
         CrewMember newLeader = crewMembers.delegateLeader(request.leaderId(), request.newLeaderId());
         return CrewLeaderDelegateResponse.of(newLeader);
+    }
+
+    @Override
+    public void deleteCrew(UUID crewId, UUID loginMemberId) {
+        Crew crew = findCrewById(crewId);
+        crew.softDelete(loginMemberId);
     }
 }

--- a/src/main/java/com/retrip/crew/application/in/usecase/ManageCrewUseCase.java
+++ b/src/main/java/com/retrip/crew/application/in/usecase/ManageCrewUseCase.java
@@ -8,8 +8,6 @@ import com.retrip.crew.application.in.response.crew.CrewCreateResponse;
 import com.retrip.crew.application.in.response.crew.CrewLeaderDelegateResponse;
 import com.retrip.crew.application.in.response.crew.CrewUpdateResponse;
 
-import com.retrip.crew.domain.entity.Crew;
-
 import java.util.UUID;
 
 public interface ManageCrewUseCase {
@@ -20,4 +18,6 @@ public interface ManageCrewUseCase {
     void withdrawCrew(UUID crewId, CrewWithdrawalRequest request);
 
     CrewLeaderDelegateResponse delegateCrewLeader(UUID crewId, CrewLeaderDelegateRequest request);
+
+    void deleteCrew(UUID crewId, UUID loginMemberId);
 }

--- a/src/main/java/com/retrip/crew/domain/entity/Crew.java
+++ b/src/main/java/com/retrip/crew/domain/entity/Crew.java
@@ -1,5 +1,7 @@
 package com.retrip.crew.domain.entity;
 
+import com.retrip.crew.domain.exception.NotCrewLeaderException;
+import com.retrip.crew.domain.exception.common.BusinessException;
 import com.retrip.crew.domain.vo.CrewDescription;
 import com.retrip.crew.domain.vo.CrewTitle;
 
@@ -14,10 +16,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.UUID;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@SQLRestriction("is_deleted = false")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE crew SET is_deleted = true WHERE id = ?")
 public class Crew extends BaseEntity {
     @Id
     @Column(columnDefinition = "varbinary(16)")
@@ -38,6 +44,9 @@ public class Crew extends BaseEntity {
     @Embedded private Introductions introductions;
 
     @Embedded private Recruitment recruitment;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
 
     private Crew(String name, String description, int maxMembers, UUID leader) {
         this.id = UUID.randomUUID();
@@ -95,5 +104,16 @@ public class Crew extends BaseEntity {
     public void approveDemand(Demand demand) {
         recruitment.approveDemand(demand);
         crewMembers.addMember(demand, this);
+    }
+
+    public void softDelete(UUID loginMemberId) {
+        validateCrewLeader(loginMemberId);
+        this.isDeleted = true;
+    }
+
+    private void validateCrewLeader(UUID loginMemberId) {
+        if(!this.getCrewMembers().isLeader(loginMemberId)){
+            throw new NotCrewLeaderException();
+        }
     }
 }

--- a/src/main/java/com/retrip/crew/infra/adapter/in/presentation/rest/CrewController.java
+++ b/src/main/java/com/retrip/crew/infra/adapter/in/presentation/rest/CrewController.java
@@ -3,6 +3,9 @@ package com.retrip.crew.infra.adapter.in.presentation.rest;
 import com.retrip.crew.application.in.request.IntroductionCreateRequest;
 import com.retrip.crew.application.in.request.IntroductionDeleteRequest;
 import com.retrip.crew.application.in.request.IntroductionUpdateRequest;
+import com.retrip.crew.application.in.request.crew.CrewCreateRequest;
+import com.retrip.crew.application.in.request.crew.CrewOrder;
+import com.retrip.crew.application.in.request.crew.CrewUpdateRequest;
 import com.retrip.crew.application.in.request.crew.*;
 import com.retrip.crew.application.in.response.IntroductionCreateResponse;
 import com.retrip.crew.application.in.response.IntroductionDetailResponse;
@@ -134,5 +137,14 @@ public class CrewController {
             @RequestBody CrewLeaderDelegateRequest request) {
         CrewLeaderDelegateResponse response = manageCrewUseCase.delegateCrewLeader(crewId, request);
         return ApiResponse.ok(response);
+    }
+
+    @Schema(description = "크루 삭제")
+    @DeleteMapping("/{crewId}")
+    public ApiResponse<?> deleteCrew(
+            @PathVariable("crewId") final UUID crewId,
+            @RequestParam("loginMemberId") UUID loginMemberId) { //TODO: 로그인 구현 될 시 해당 부분 교체 해야함 임시방편으로 쿼리 파라미터에 넣음
+        manageCrewUseCase.deleteCrew(crewId, loginMemberId);
+        return ApiResponse.noContent();
     }
 }

--- a/src/test/java/com/retrip/crew/application/in/CrewServiceTest.java
+++ b/src/test/java/com/retrip/crew/application/in/CrewServiceTest.java
@@ -14,8 +14,11 @@ import com.retrip.crew.application.in.response.crew.CrewListResponse;
 import com.retrip.crew.application.in.response.crew.CrewUpdateResponse;
 import com.retrip.crew.common.ServiceTest;
 import com.retrip.crew.domain.entity.Crew;
+import com.retrip.crew.domain.entity.CrewMember;
 import com.retrip.crew.domain.entity.CrewMemberRole;
+import com.retrip.crew.domain.entity.Demand;
 import com.retrip.crew.domain.entity.Introduction;
+import com.retrip.crew.domain.exception.NotCrewLeaderException;
 import com.retrip.crew.domain.exception.common.InvalidAccessException;
 import com.retrip.crew.infra.adapter.in.presentation.rest.common.ScrollPageResponse;
 import org.junit.jupiter.api.Test;
@@ -247,5 +250,41 @@ class CrewServiceTest extends ServiceTest {
         assertThat(response.introductionId()).isEqualTo(introduction.getId());
         assertThat(response.content()).isEqualTo("안녕하세요!");
         assertThat(response.title()).isEqualTo("정수의 자기소개!");
+    }
+
+    @Test
+    void 리더가_크루를_탈퇴한다() {
+        // given
+        Crew crew = Crew.create(
+                "속초 크루원 구함",
+                "속초 친구 구합니다! 나이는 20~40.. 많은 가입 부탁드립니다.",
+                100,
+                MEMBER_ID
+        );
+        Crew savedCrew = crewRepository.save(crew);
+
+        // when
+        crewService.deleteCrew(savedCrew.getId(), MEMBER_ID);
+        Crew deletedCrew = crewRepository.findById(savedCrew.getId()).get();
+
+        // then
+        assertThat(deletedCrew.isDeleted()).isTrue();
+    }
+
+    @Test
+    void 리더가_아니면_크루를_탈퇴할_수_없다() {
+        // given
+        Crew crew = Crew.create(
+                "속초 크루원 구함",
+                "속초 친구 구합니다! 나이는 20~40.. 많은 가입 부탁드립니다.",
+                100,
+                LEADER_ID
+        );
+        Crew savedCrew = crewRepository.save(crew);
+        Demand demand = savedCrew.demand(MEMBER_ID);
+        savedCrew.approveDemand(demand);
+
+        // when && then
+        assertThrows(NotCrewLeaderException.class, () -> crewService.deleteCrew(savedCrew.getId(), MEMBER_ID));
     }
 }


### PR DESCRIPTION
## 🔍 PR 타입 선택

아래 타입 중 해당하는 하나를 선택해 주세요. 반드시 하나만 선택해 주세요.

- [x] `feat`: 새로운 기능 추가
- [ ] `fix`: 버그 수정
- [ ] `docs`: 문서 수정
- [ ] `style`: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] `refactor`: 코드 리팩토링
- [ ] `test`: 테스트 코드 추가 또는 수정
- [ ] `chore`: 빌드 업무 수정, 패키지 매니저 수정 등 기타 작업


## 📝 변경 사항 요약

- 리더가 크루를 논리적으로 삭제할 수 있는 API를 구현함
- 크루 관련 조회할 때 is_deleted = false 인 것을 자동적으로 쿼리에 넣도록 Entity에 어노테이션 추가


## 🛠 관련 이슈

Resolves: #6 
Ref: #6  
Related to: #6 
close: #6 

### **추가 설명 (선택 사항)**

변경 사항에 대한 추가 설명을 작성해 주세요.
